### PR TITLE
ci(npm): use trusted publishing

### DIFF
--- a/.github/workflows/tags.yml
+++ b/.github/workflows/tags.yml
@@ -3,6 +3,10 @@ on:
     tags:
       - '*'
 
+permissions:
+  id-token: write  # Required for OIDC
+  contents: read
+
 jobs:
   angular:
     uses: ./.github/workflows/angular.yml
@@ -15,7 +19,7 @@ jobs:
         with:
           name: lib-build
           path: dist/ngx-openlayers/
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{env.NODE_JS_VERSION}}
           cache: 'yarn'
@@ -33,8 +37,6 @@ jobs:
           fi
       - run: cp projects/ngx-openlayers/CHANGELOG.md dist/ngx-openlayers/CHANGELOG.md
       - run: cd dist/ngx-openlayers/ && npm publish --tag ${{ steps.check-tag.outputs.tag }} --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
     needs:
       - angular
 


### PR DESCRIPTION
Use new trusted publishing method with tokens for deploying NPM packages : https://docs.npmjs.com/trusted-publishers