### PR TITLE
fix: manage component destruction if map not instantiated

### DIFF
--- a/projects/ngx-openlayers/src/lib/attribution.component.ts
+++ b/projects/ngx-openlayers/src/lib/attribution.component.ts
@@ -9,7 +9,7 @@ import { Attribution } from 'ol/control';
 export class AttributionComponent implements OnInit {
   private elementRef = inject(ElementRef);
 
-  instance: Attribution;
+  instance?: Attribution;
   html: string;
 
   ngOnInit(): void {

--- a/projects/ngx-openlayers/src/lib/attributions.component.ts
+++ b/projects/ngx-openlayers/src/lib/attributions.component.ts
@@ -13,14 +13,14 @@ export class AttributionsComponent implements AfterViewInit {
   @ContentChildren(AttributionComponent)
   attributions: QueryList<AttributionComponent>;
 
-  instance: Array<string>;
+  instance?: Array<string>;
 
   /* we can do this at the very end */
   ngAfterViewInit(): void {
     if (this.attributions.length) {
       this.instance = this.attributions.map((cmp) => cmp.html);
       // console.log('setting attributions:', this.instance);
-      this.source.instance.setAttributions(this.instance);
+      this.source.instance?.setAttributions(this.instance);
     }
   }
 }

--- a/projects/ngx-openlayers/src/lib/collectioncoordinates.component.ts
+++ b/projects/ngx-openlayers/src/lib/collectioncoordinates.component.ts
@@ -51,9 +51,11 @@ export class CollectionCoordinatesComponent implements OnChanges, OnInit {
   }
 
   ngOnInit(): void {
-    this.map.instance.on('change:view', (e) => this.onMapViewChanged(e));
-    this.mapSrid = this.map.instance.getView().getProjection().getCode();
-    this.transformCoordinates();
+    if (this.map.instance) {
+      this.map.instance.on('change:view', (e) => this.onMapViewChanged(e));
+      this.mapSrid = this.map.instance.getView().getProjection().getCode();
+      this.transformCoordinates();
+    }
   }
 
   ngOnChanges(): void {

--- a/projects/ngx-openlayers/src/lib/controls/attribution.component.ts
+++ b/projects/ngx-openlayers/src/lib/controls/attribution.component.ts
@@ -8,25 +8,27 @@ import { MapComponent } from '../map.component';
   standalone: true,
 })
 export class ControlAttributionComponent implements OnInit, OnDestroy {
-  private map = inject(MapComponent);
+  private map = inject(MapComponent, { host: true });
   private element = inject(ElementRef);
 
   @Input()
   collapsible: boolean;
 
   componentType = 'control';
-  instance: Attribution;
+  instance?: Attribution;
   target: HTMLElement;
 
   ngOnInit(): void {
     this.target = this.element.nativeElement;
     // console.log('ol.control.Attribution init: ', this);
     this.instance = new Attribution(this);
-    this.map.instance.addControl(this.instance);
+    this.map.instance?.addControl(this.instance);
   }
 
   ngOnDestroy(): void {
-    // console.log('removing aol-control-attribution');
-    this.map.instance.removeControl(this.instance);
+    if (this.instance) {
+      // console.log('removing aol-control-attribution');
+      this.map.instance?.removeControl(this.instance);
+    }
   }
 }

--- a/projects/ngx-openlayers/src/lib/controls/control.component.ts
+++ b/projects/ngx-openlayers/src/lib/controls/control.component.ts
@@ -9,26 +9,26 @@ import { MapComponent } from '../map.component';
   standalone: true,
 })
 export class ControlComponent implements OnInit, OnDestroy {
-  private map = inject(MapComponent);
+  private map = inject(MapComponent, { host: true });
 
   @ContentChild(ContentComponent, { static: true })
   content: ContentComponent;
 
   componentType = 'control';
-  instance: Control;
+  instance?: Control;
   element: HTMLElement;
 
   ngOnInit(): void {
     if (this.content) {
       this.element = this.content.elementRef.nativeElement;
       this.instance = new Control(this);
-      this.map.instance.addControl(this.instance);
+      this.map.instance?.addControl(this.instance);
     }
   }
 
   ngOnDestroy(): void {
     if (this.instance) {
-      this.map.instance.removeControl(this.instance);
+      this.map.instance?.removeControl(this.instance);
     }
   }
 }

--- a/projects/ngx-openlayers/src/lib/controls/default.component.ts
+++ b/projects/ngx-openlayers/src/lib/controls/default.component.ts
@@ -13,7 +13,7 @@ import { MapComponent } from '../map.component';
   standalone: true,
 })
 export class DefaultControlComponent implements OnInit, OnDestroy {
-  private map = inject(MapComponent);
+  private map = inject(MapComponent, { host: true });
 
   @Input()
   attribution: boolean;
@@ -28,16 +28,16 @@ export class DefaultControlComponent implements OnInit, OnDestroy {
   @Input()
   zoomOptions: ZoomOptions;
 
-  instance: Collection<Control>;
+  instance?: Collection<Control>;
 
   ngOnInit(): void {
     // console.log('ol.control.defaults init: ', this);
     this.instance = defaults(this);
-    this.instance.forEach((c) => this.map.instance.addControl(c));
+    this.instance.forEach((c) => this.map.instance?.addControl(c));
   }
 
   ngOnDestroy(): void {
     // console.log('removing aol-control-defaults');
-    this.instance.forEach((c) => this.map.instance.removeControl(c));
+    this.instance?.forEach((c) => this.map.instance?.removeControl(c));
   }
 }

--- a/projects/ngx-openlayers/src/lib/controls/fullscreen.component.ts
+++ b/projects/ngx-openlayers/src/lib/controls/fullscreen.component.ts
@@ -8,7 +8,7 @@ import { MapComponent } from '../map.component';
   standalone: true,
 })
 export class ControlFullScreenComponent implements OnInit, OnDestroy {
-  private map = inject(MapComponent);
+  private map = inject(MapComponent, { host: true });
 
   @Input()
   className: string;
@@ -21,15 +21,17 @@ export class ControlFullScreenComponent implements OnInit, OnDestroy {
   @Input()
   keys: boolean;
 
-  instance: FullScreen;
+  instance?: FullScreen;
 
   ngOnInit(): void {
     this.instance = new FullScreen(this);
-    this.map.instance.addControl(this.instance);
+    this.map.instance?.addControl(this.instance);
   }
 
   ngOnDestroy(): void {
-    // console.log('removing aol-control-fullscreen');
-    this.map.instance.removeControl(this.instance);
+    if (this.instance) {
+      // console.log('removing aol-control-fullscreen');
+      this.map.instance?.removeControl(this.instance);
+    }
   }
 }

--- a/projects/ngx-openlayers/src/lib/controls/mouseposition.component.ts
+++ b/projects/ngx-openlayers/src/lib/controls/mouseposition.component.ts
@@ -10,7 +10,7 @@ import { MapComponent } from '../map.component';
   standalone: true,
 })
 export class ControlMousePositionComponent implements OnInit, OnDestroy {
-  private map = inject(MapComponent);
+  private map = inject(MapComponent, { host: true });
   private element = inject(ElementRef);
 
   @Input()
@@ -21,17 +21,19 @@ export class ControlMousePositionComponent implements OnInit, OnDestroy {
   wrapX: boolean;
   target: HTMLElement;
 
-  instance: MousePosition;
+  instance?: MousePosition;
 
   ngOnInit(): void {
     this.target = this.element.nativeElement;
     // console.log('ol.control.MousePosition init: ', this);
     this.instance = new MousePosition(this);
-    this.map.instance.addControl(this.instance);
+    this.map.instance?.addControl(this.instance);
   }
 
   ngOnDestroy(): void {
-    // console.log('removing aol-control-mouseposition');
-    this.map.instance.removeControl(this.instance);
+    if (this.instance) {
+      // console.log('removing aol-control-mouseposition');
+      this.map.instance?.removeControl(this.instance);
+    }
   }
 }

--- a/projects/ngx-openlayers/src/lib/controls/overviewmap.component.ts
+++ b/projects/ngx-openlayers/src/lib/controls/overviewmap.component.ts
@@ -10,7 +10,7 @@ import { MapComponent } from '../map.component';
   standalone: true,
 })
 export class ControlOverviewMapComponent implements OnInit, OnChanges, OnDestroy {
-  private map = inject(MapComponent);
+  private map = inject(MapComponent, { host: true });
 
   @Input()
   collapsed: boolean;
@@ -29,15 +29,17 @@ export class ControlOverviewMapComponent implements OnInit, OnChanges, OnDestroy
   @Input()
   view: View;
 
-  instance: OverviewMap;
+  instance?: OverviewMap;
 
   ngOnInit(): void {
     this.instance = new OverviewMap(this);
-    this.map.instance.addControl(this.instance);
+    this.map.instance?.addControl(this.instance);
   }
 
   ngOnDestroy(): void {
-    this.map.instance.removeControl(this.instance);
+    if (this.instance) {
+      this.map.instance?.removeControl(this.instance);
+    }
   }
 
   ngOnChanges(changes: SimpleChanges): void {
@@ -47,8 +49,10 @@ export class ControlOverviewMapComponent implements OnInit, OnChanges, OnDestroy
   }
 
   private reloadInstance(): void {
-    this.map.instance.removeControl(this.instance);
+    if (this.instance) {
+      this.map.instance?.removeControl(this.instance);
+    }
     this.instance = new OverviewMap(this);
-    this.map.instance.addControl(this.instance);
+    this.map.instance?.addControl(this.instance);
   }
 }

--- a/projects/ngx-openlayers/src/lib/controls/rotate.component.ts
+++ b/projects/ngx-openlayers/src/lib/controls/rotate.component.ts
@@ -8,7 +8,7 @@ import { MapComponent } from '../map.component';
   standalone: true,
 })
 export class ControlRotateComponent implements OnInit, OnDestroy {
-  private map = inject(MapComponent);
+  private map = inject(MapComponent, { host: true });
 
   @Input()
   className: string;
@@ -21,15 +21,17 @@ export class ControlRotateComponent implements OnInit, OnDestroy {
   @Input()
   autoHide: boolean;
 
-  instance: Rotate;
+  instance?: Rotate;
 
   ngOnInit(): void {
     this.instance = new Rotate(this);
-    this.map.instance.addControl(this.instance);
+    this.map.instance?.addControl(this.instance);
   }
 
   ngOnDestroy(): void {
-    // console.log('removing aol-control-rotate');
-    this.map.instance.removeControl(this.instance);
+    if (this.instance) {
+      // console.log('removing aol-control-rotate');
+      this.map.instance?.removeControl(this.instance);
+    }
   }
 }

--- a/projects/ngx-openlayers/src/lib/controls/scaleline.component.ts
+++ b/projects/ngx-openlayers/src/lib/controls/scaleline.component.ts
@@ -9,20 +9,22 @@ import { Units } from 'ol/control/ScaleLine';
   standalone: true,
 })
 export class ControlScaleLineComponent implements OnInit, OnDestroy {
-  private map = inject(MapComponent);
+  private map = inject(MapComponent, { host: true });
 
   @Input()
   units: Units;
 
-  instance: ScaleLine;
+  instance?: ScaleLine;
 
   ngOnInit(): void {
     this.instance = new ScaleLine(this);
-    this.map.instance.addControl(this.instance);
+    this.map.instance?.addControl(this.instance);
   }
 
   ngOnDestroy(): void {
-    // console.log('removing aol-control-scaleline');
-    this.map.instance.removeControl(this.instance);
+    if (this.instance) {
+      // console.log('removing aol-control-scaleline');
+      this.map.instance?.removeControl(this.instance);
+    }
   }
 }

--- a/projects/ngx-openlayers/src/lib/controls/zoom.component.ts
+++ b/projects/ngx-openlayers/src/lib/controls/zoom.component.ts
@@ -8,7 +8,7 @@ import { MapComponent } from '../map.component';
   standalone: true,
 })
 export class ControlZoomComponent implements OnInit, OnDestroy {
-  private map = inject(MapComponent);
+  private map = inject(MapComponent, { host: true });
 
   @Input()
   duration: number;
@@ -23,15 +23,17 @@ export class ControlZoomComponent implements OnInit, OnDestroy {
   @Input()
   delta: number;
 
-  instance: Zoom;
+  instance?: Zoom;
 
   ngOnInit(): void {
     this.instance = new Zoom(this);
-    this.map.instance.addControl(this.instance);
+    this.map.instance?.addControl(this.instance);
   }
 
   ngOnDestroy(): void {
-    // console.log('removing aol-control-zoom');
-    this.map.instance.removeControl(this.instance);
+    if (this.instance) {
+      // console.log('removing aol-control-zoom');
+      this.map.instance?.removeControl(this.instance);
+    }
   }
 }

--- a/projects/ngx-openlayers/src/lib/controls/zoomslider.component.ts
+++ b/projects/ngx-openlayers/src/lib/controls/zoomslider.component.ts
@@ -8,7 +8,7 @@ import { MapComponent } from '../map.component';
   standalone: true,
 })
 export class ControlZoomSliderComponent implements OnInit, OnDestroy {
-  private map = inject(MapComponent);
+  private map = inject(MapComponent, { host: true });
 
   @Input()
   className: string;
@@ -19,15 +19,17 @@ export class ControlZoomSliderComponent implements OnInit, OnDestroy {
   @Input()
   minResolution: number;
 
-  instance: ZoomSlider;
+  instance?: ZoomSlider;
 
   ngOnInit(): void {
     this.instance = new ZoomSlider(this);
-    this.map.instance.addControl(this.instance);
+    this.map.instance?.addControl(this.instance);
   }
 
   ngOnDestroy(): void {
-    // console.log('removing aol-control-zoomslider');
-    this.map.instance.removeControl(this.instance);
+    if (this.instance) {
+      // console.log('removing aol-control-zoomslider');
+      this.map.instance?.removeControl(this.instance);
+    }
   }
 }

--- a/projects/ngx-openlayers/src/lib/controls/zoomtoextent.component.ts
+++ b/projects/ngx-openlayers/src/lib/controls/zoomtoextent.component.ts
@@ -9,7 +9,7 @@ import { MapComponent } from '../map.component';
   standalone: true,
 })
 export class ControlZoomToExtentComponent implements OnInit, OnDestroy {
-  private map = inject(MapComponent);
+  private map = inject(MapComponent, { host: true });
 
   @Input()
   className: string;
@@ -20,15 +20,17 @@ export class ControlZoomToExtentComponent implements OnInit, OnDestroy {
   @Input()
   extent: Extent;
 
-  instance: ZoomToExtent;
+  instance?: ZoomToExtent;
 
   ngOnInit(): void {
     this.instance = new ZoomToExtent(this);
-    this.map.instance.addControl(this.instance);
+    this.map.instance?.addControl(this.instance);
   }
 
   ngOnDestroy(): void {
-    // console.log('removing aol-control-zoomtoextent');
-    this.map.instance.removeControl(this.instance);
+    if (this.instance) {
+      // console.log('removing aol-control-zoomtoextent');
+      this.map.instance?.removeControl(this.instance);
+    }
   }
 }

--- a/projects/ngx-openlayers/src/lib/coordinate.component.ts
+++ b/projects/ngx-openlayers/src/lib/coordinate.component.ts
@@ -43,8 +43,10 @@ export class CoordinateComponent implements OnChanges, OnInit {
   }
 
   ngOnInit(): void {
-    this.map.instance.on('change:view', (e) => this.onMapViewChanged(e));
-    this.mapSrid = this.map.instance.getView().getProjection().getCode();
+    if (this.map.instance) {
+      this.map.instance.on('change:view', (e) => this.onMapViewChanged(e));
+      this.mapSrid = this.map.instance.getView().getProjection().getCode();
+    }
     this.transformCoordinates();
   }
 
@@ -69,9 +71,9 @@ export class CoordinateComponent implements OnChanges, OnInit {
     if (this.host instanceof GeometryPointComponent) {
       this.host.instance.setCoordinates(transformedCoordinates);
     } else if (this.host instanceof OverlayComponent) {
-      this.host.instance.setPosition(transformedCoordinates);
+      this.host.instance?.setPosition(transformedCoordinates);
     } else {
-      this.host.instance.setCenter(transformedCoordinates);
+      this.host.instance?.setCenter(transformedCoordinates);
     }
   }
 }

--- a/projects/ngx-openlayers/src/lib/feature.component.ts
+++ b/projects/ngx-openlayers/src/lib/feature.component.ts
@@ -14,18 +14,20 @@ export class FeatureComponent implements OnInit, OnDestroy, OnChanges {
   id: string | number | undefined;
 
   componentType = 'feature';
-  instance: Feature;
+  instance?: Feature;
 
   ngOnInit(): void {
     this.instance = new Feature();
     if (this.id !== undefined) {
       this.instance.setId(this.id);
     }
-    this.host.instance.addFeature(this.instance);
+    this.host.instance?.addFeature(this.instance);
   }
 
   ngOnDestroy(): void {
-    this.host.instance.removeFeature(this.instance);
+    if (this.instance) {
+      this.host.instance?.removeFeature(this.instance);
+    }
   }
 
   ngOnChanges(): void {

--- a/projects/ngx-openlayers/src/lib/formats/format.component.ts
+++ b/projects/ngx-openlayers/src/lib/formats/format.component.ts
@@ -2,6 +2,6 @@ import FeatureFormat from 'ol/format/Feature';
 import RenderFeature from 'ol/render/Feature';
 
 export class FormatComponent {
-  public instance: FeatureFormat<RenderFeature>;
+  public instance?: FeatureFormat<RenderFeature>;
   public componentType = 'format';
 }

--- a/projects/ngx-openlayers/src/lib/formats/mvt.component.ts
+++ b/projects/ngx-openlayers/src/lib/formats/mvt.component.ts
@@ -20,7 +20,7 @@ export class FormatMVTComponent extends FormatComponent {
   @Input()
   layers: string[];
 
-  instance: MVT;
+  instance?: MVT;
 
   constructor() {
     super();

--- a/projects/ngx-openlayers/src/lib/geom/simplegeometry.component.ts
+++ b/projects/ngx-openlayers/src/lib/geom/simplegeometry.component.ts
@@ -7,13 +7,13 @@ import { MapComponent } from '../map.component';
 export abstract class SimpleGeometryComponent implements OnInit {
   @Input() srid: string;
 
-  instance: SimpleGeometry;
+  instance?: SimpleGeometry;
   componentType = 'simple-geometry';
 
   protected readonly map = inject(MapComponent);
   protected readonly host = inject(FeatureComponent);
 
   ngOnInit(): void {
-    this.host.instance.setGeometry(this.instance);
+    this.host.instance?.setGeometry(this.instance);
   }
 }

--- a/projects/ngx-openlayers/src/lib/graticule.component.ts
+++ b/projects/ngx-openlayers/src/lib/graticule.component.ts
@@ -21,7 +21,7 @@ export class GraticuleComponent implements AfterContentInit, OnChanges, OnDestro
   @Input()
   latLabelPosition: number;
 
-  instance: Graticule;
+  instance?: Graticule;
   componentType = 'graticule';
 
   ngOnChanges(changes: SimpleChanges): void {
@@ -35,7 +35,9 @@ export class GraticuleComponent implements AfterContentInit, OnChanges, OnDestro
     if (properties) {
       this.instance = new Graticule(properties);
     }
-    this.instance.setMap(this.map.instance);
+    if (this.map.instance) {
+      this.instance.setMap(this.map.instance);
+    }
   }
 
   ngAfterContentInit(): void {
@@ -45,10 +47,12 @@ export class GraticuleComponent implements AfterContentInit, OnChanges, OnDestro
       lonLabelPosition: this.lonLabelPosition,
       latLabelPosition: this.latLabelPosition,
     });
-    this.instance.setMap(this.map.instance);
+    if (this.map.instance) {
+      this.instance.setMap(this.map.instance);
+    }
   }
 
   ngOnDestroy(): void {
-    this.instance.setMap(null);
+    this.instance?.setMap(null);
   }
 }

--- a/projects/ngx-openlayers/src/lib/interactions/default.component.ts
+++ b/projects/ngx-openlayers/src/lib/interactions/default.component.ts
@@ -9,16 +9,16 @@ import { MapComponent } from '../map.component';
   standalone: true,
 })
 export class DefaultInteractionComponent implements OnInit, OnDestroy {
-  private map = inject(MapComponent);
+  private map = inject(MapComponent, { host: true });
 
-  instance: Collection<Interaction>;
+  instance?: Collection<Interaction>;
 
   ngOnInit(): void {
     this.instance = defaults();
-    this.instance.forEach((i) => this.map.instance.addInteraction(i));
+    this.instance.forEach((i) => this.map.instance?.addInteraction(i));
   }
 
   ngOnDestroy(): void {
-    this.instance.forEach((i) => this.map.instance.removeInteraction(i));
+    this.instance?.forEach((i) => this.map.instance?.removeInteraction(i));
   }
 }

--- a/projects/ngx-openlayers/src/lib/interactions/doubleclickzoom.component.ts
+++ b/projects/ngx-openlayers/src/lib/interactions/doubleclickzoom.component.ts
@@ -8,21 +8,23 @@ import { MapComponent } from '../map.component';
   standalone: true,
 })
 export class DoubleClickZoomInteractionComponent implements OnInit, OnDestroy {
-  private map = inject(MapComponent);
+  private map = inject(MapComponent, { host: true });
 
   @Input()
   duration: number;
   @Input()
   delta: number;
 
-  instance: DoubleClickZoom;
+  instance?: DoubleClickZoom;
 
   ngOnInit(): void {
     this.instance = new DoubleClickZoom(this);
-    this.map.instance.addInteraction(this.instance);
+    this.map.instance?.addInteraction(this.instance);
   }
 
   ngOnDestroy(): void {
-    this.map.instance.removeInteraction(this.instance);
+    if (this.instance) {
+      this.map.instance?.removeInteraction(this.instance);
+    }
   }
 }

--- a/projects/ngx-openlayers/src/lib/interactions/draganddrop.component.ts
+++ b/projects/ngx-openlayers/src/lib/interactions/draganddrop.component.ts
@@ -10,7 +10,7 @@ import { MapComponent } from '../map.component';
   standalone: true,
 })
 export class DragAndDropInteractionComponent implements OnInit, OnDestroy {
-  private map = inject(MapComponent);
+  private map = inject(MapComponent, { host: true });
 
   @Input()
   formatConstructors: FeatureFormat[];
@@ -19,14 +19,16 @@ export class DragAndDropInteractionComponent implements OnInit, OnDestroy {
   @Input()
   target: HTMLElement;
 
-  instance: DragAndDrop;
+  instance?: DragAndDrop;
 
   ngOnInit(): void {
     this.instance = new DragAndDrop(this);
-    this.map.instance.addInteraction(this.instance);
+    this.map.instance?.addInteraction(this.instance);
   }
 
   ngOnDestroy(): void {
-    this.map.instance.removeInteraction(this.instance);
+    if (this.instance) {
+      this.map.instance?.removeInteraction(this.instance);
+    }
   }
 }

--- a/projects/ngx-openlayers/src/lib/interactions/dragbox.component.ts
+++ b/projects/ngx-openlayers/src/lib/interactions/dragbox.component.ts
@@ -10,7 +10,7 @@ import { MapComponent } from '../map.component';
   standalone: true,
 })
 export class DragBoxInteractionComponent implements OnInit, OnDestroy {
-  private map = inject(MapComponent);
+  private map = inject(MapComponent, { host: true });
 
   @Input()
   className: string;
@@ -19,14 +19,16 @@ export class DragBoxInteractionComponent implements OnInit, OnDestroy {
   @Input()
   boxEndCondition: EndCondition;
 
-  instance: DragBox;
+  instance?: DragBox;
 
   ngOnInit(): void {
     this.instance = new DragBox(this);
-    this.map.instance.addInteraction(this.instance);
+    this.map.instance?.addInteraction(this.instance);
   }
 
   ngOnDestroy(): void {
-    this.map.instance.removeInteraction(this.instance);
+    if (this.instance) {
+      this.map.instance?.removeInteraction(this.instance);
+    }
   }
 }

--- a/projects/ngx-openlayers/src/lib/interactions/dragpan.component.ts
+++ b/projects/ngx-openlayers/src/lib/interactions/dragpan.component.ts
@@ -10,21 +10,23 @@ import { MapComponent } from '../map.component';
   standalone: true,
 })
 export class DragPanInteractionComponent implements OnInit, OnDestroy {
-  private map = inject(MapComponent);
+  private map = inject(MapComponent, { host: true });
 
   @Input()
   condition: Condition;
   @Input()
   kinetic: Kinetic;
 
-  instance: DragPan;
+  instance?: DragPan;
 
   ngOnInit(): void {
     this.instance = new DragPan(this);
-    this.map.instance.addInteraction(this.instance);
+    this.map.instance?.addInteraction(this.instance);
   }
 
   ngOnDestroy(): void {
-    this.map.instance.removeInteraction(this.instance);
+    if (this.instance) {
+      this.map.instance?.removeInteraction(this.instance);
+    }
   }
 }

--- a/projects/ngx-openlayers/src/lib/interactions/dragrotate.component.ts
+++ b/projects/ngx-openlayers/src/lib/interactions/dragrotate.component.ts
@@ -9,21 +9,23 @@ import { MapComponent } from '../map.component';
   standalone: true,
 })
 export class DragRotateInteractionComponent implements OnInit, OnDestroy {
-  private map = inject(MapComponent);
+  private map = inject(MapComponent, { host: true });
 
   @Input()
   condition: Condition;
   @Input()
   duration: number;
 
-  instance: DragRotate;
+  instance?: DragRotate;
 
   ngOnInit(): void {
     this.instance = new DragRotate(this);
-    this.map.instance.addInteraction(this.instance);
+    this.map.instance?.addInteraction(this.instance);
   }
 
   ngOnDestroy(): void {
-    this.map.instance.removeInteraction(this.instance);
+    if (this.instance) {
+      this.map.instance?.removeInteraction(this.instance);
+    }
   }
 }

--- a/projects/ngx-openlayers/src/lib/interactions/dragrotateandzoom.component.ts
+++ b/projects/ngx-openlayers/src/lib/interactions/dragrotateandzoom.component.ts
@@ -9,21 +9,23 @@ import { MapComponent } from '../map.component';
   standalone: true,
 })
 export class DragRotateAndZoomInteractionComponent implements OnInit, OnDestroy {
-  private map = inject(MapComponent);
+  private map = inject(MapComponent, { host: true });
 
   @Input()
   condition: Condition;
   @Input()
   duration: number;
 
-  instance: DragRotateAndZoom;
+  instance?: DragRotateAndZoom;
 
   ngOnInit(): void {
     this.instance = new DragRotateAndZoom(this);
-    this.map.instance.addInteraction(this.instance);
+    this.map.instance?.addInteraction(this.instance);
   }
 
   ngOnDestroy(): void {
-    this.map.instance.removeInteraction(this.instance);
+    if (this.instance) {
+      this.map.instance?.removeInteraction(this.instance);
+    }
   }
 }

--- a/projects/ngx-openlayers/src/lib/interactions/dragzoom.component.ts
+++ b/projects/ngx-openlayers/src/lib/interactions/dragzoom.component.ts
@@ -9,7 +9,7 @@ import { MapComponent } from '../map.component';
   standalone: true,
 })
 export class DragZoomInteractionComponent implements OnInit, OnDestroy {
-  private map = inject(MapComponent);
+  private map = inject(MapComponent, { host: true });
 
   @Input()
   className: string;
@@ -20,14 +20,16 @@ export class DragZoomInteractionComponent implements OnInit, OnDestroy {
   @Input()
   out: boolean;
 
-  instance: DragZoom;
+  instance?: DragZoom;
 
   ngOnInit(): void {
     this.instance = new DragZoom(this);
-    this.map.instance.addInteraction(this.instance);
+    this.map.instance?.addInteraction(this.instance);
   }
 
   ngOnDestroy(): void {
-    this.map.instance.removeInteraction(this.instance);
+    if (this.instance) {
+      this.map.instance?.removeInteraction(this.instance);
+    }
   }
 }

--- a/projects/ngx-openlayers/src/lib/interactions/draw.component.ts
+++ b/projects/ngx-openlayers/src/lib/interactions/draw.component.ts
@@ -16,7 +16,7 @@ import { Type } from 'ol/geom/Geometry';
   standalone: true,
 })
 export class DrawInteractionComponent implements OnInit, OnDestroy {
-  private map = inject(MapComponent);
+  private map = inject(MapComponent, { host: true });
 
   @Input()
   clickTolerance?: number;
@@ -60,7 +60,7 @@ export class DrawInteractionComponent implements OnInit, OnDestroy {
   @Output()
   propertyChange = new EventEmitter<ObjectEvent>();
 
-  instance: Draw;
+  instance?: Draw;
 
   ngOnInit(): void {
     this.instance = new Draw(this);
@@ -69,10 +69,12 @@ export class DrawInteractionComponent implements OnInit, OnDestroy {
     this.instance.on('drawend', (event: DrawEvent) => this.drawEnd.emit(event));
     this.instance.on('drawstart', (event: DrawEvent) => this.drawStart.emit(event));
     this.instance.on('propertychange', (event: ObjectEvent) => this.propertyChange.emit(event));
-    this.map.instance.addInteraction(this.instance);
+    this.map.instance?.addInteraction(this.instance);
   }
 
   ngOnDestroy(): void {
-    this.map.instance.removeInteraction(this.instance);
+    if (this.instance) {
+      this.map.instance?.removeInteraction(this.instance);
+    }
   }
 }

--- a/projects/ngx-openlayers/src/lib/interactions/modify.component.ts
+++ b/projects/ngx-openlayers/src/lib/interactions/modify.component.ts
@@ -15,7 +15,7 @@ import { MapComponent } from '../map.component';
   standalone: true,
 })
 export class ModifyInteractionComponent implements OnInit, OnDestroy {
-  private map = inject(MapComponent);
+  private map = inject(MapComponent, { host: true });
 
   @Input()
   condition?: Condition;
@@ -43,7 +43,7 @@ export class ModifyInteractionComponent implements OnInit, OnDestroy {
   @Output()
   propertyChange = new EventEmitter<ObjectEvent>();
 
-  instance: Modify;
+  instance?: Modify;
 
   ngOnInit(): void {
     this.instance = new Modify(this);
@@ -52,10 +52,12 @@ export class ModifyInteractionComponent implements OnInit, OnDestroy {
     this.instance.on('propertychange', (event: ObjectEvent) => this.propertyChange.emit(event));
     this.instance.on('modifyend', (event: ModifyEvent) => this.modifyEnd.emit(event));
     this.instance.on('modifystart', (event: ModifyEvent) => this.modifyStart.emit(event));
-    this.map.instance.addInteraction(this.instance);
+    this.map.instance?.addInteraction(this.instance);
   }
 
   ngOnDestroy(): void {
-    this.map.instance.removeInteraction(this.instance);
+    if (this.instance) {
+      this.map.instance?.removeInteraction(this.instance);
+    }
   }
 }

--- a/projects/ngx-openlayers/src/lib/interactions/mousewheelzoom.component.ts
+++ b/projects/ngx-openlayers/src/lib/interactions/mousewheelzoom.component.ts
@@ -8,7 +8,7 @@ import { MapComponent } from '../map.component';
   standalone: true,
 })
 export class MouseWheelZoomInteractionComponent implements OnInit, OnDestroy {
-  private map = inject(MapComponent);
+  private map = inject(MapComponent, { host: true });
 
   @Input()
   duration: number;
@@ -17,14 +17,16 @@ export class MouseWheelZoomInteractionComponent implements OnInit, OnDestroy {
   @Input()
   useAnchor: boolean;
 
-  instance: MouseWheelZoom;
+  instance?: MouseWheelZoom;
 
   ngOnInit(): void {
     this.instance = new MouseWheelZoom(this);
-    this.map.instance.addInteraction(this.instance);
+    this.map.instance?.addInteraction(this.instance);
   }
 
   ngOnDestroy(): void {
-    this.map.instance.removeInteraction(this.instance);
+    if (this.instance) {
+      this.map.instance?.removeInteraction(this.instance);
+    }
   }
 }

--- a/projects/ngx-openlayers/src/lib/interactions/pinchzoom.component.ts
+++ b/projects/ngx-openlayers/src/lib/interactions/pinchzoom.component.ts
@@ -8,21 +8,23 @@ import { MapComponent } from '../map.component';
   standalone: true,
 })
 export class PinchZoomInteractionComponent implements OnInit, OnDestroy {
-  private map = inject(MapComponent);
+  private map = inject(MapComponent, { host: true });
 
   @Input()
   duration: number;
   @Input()
   constrainResolution: boolean;
 
-  instance: PinchZoom;
+  instance?: PinchZoom;
 
   ngOnInit(): void {
     this.instance = new PinchZoom(this);
-    this.map.instance.addInteraction(this.instance);
+    this.map.instance?.addInteraction(this.instance);
   }
 
   ngOnDestroy(): void {
-    this.map.instance.removeInteraction(this.instance);
+    if (this.instance) {
+      this.map.instance?.removeInteraction(this.instance);
+    }
   }
 }

--- a/projects/ngx-openlayers/src/lib/interactions/select.component.ts
+++ b/projects/ngx-openlayers/src/lib/interactions/select.component.ts
@@ -15,7 +15,7 @@ import { MapComponent } from '../map.component';
   standalone: true,
 })
 export class SelectInteractionComponent implements OnInit, OnDestroy {
-  private map = inject(MapComponent);
+  private map = inject(MapComponent, { host: true });
 
   @Input()
   addCondition?: Condition;
@@ -45,7 +45,7 @@ export class SelectInteractionComponent implements OnInit, OnDestroy {
   @Output()
   propertyChange = new EventEmitter<ObjectEvent>();
 
-  instance: Select;
+  instance?: Select;
 
   ngOnInit(): void {
     this.instance = new Select(this);
@@ -54,10 +54,12 @@ export class SelectInteractionComponent implements OnInit, OnDestroy {
     this.instance.on('select', (event: SelectEvent) => this.olSelect.emit(event));
     this.instance.on('propertychange', (event: ObjectEvent) => this.propertyChange.emit(event));
 
-    this.map.instance.addInteraction(this.instance);
+    this.map.instance?.addInteraction(this.instance);
   }
 
   ngOnDestroy(): void {
-    this.map.instance.removeInteraction(this.instance);
+    if (this.instance) {
+      this.map.instance?.removeInteraction(this.instance);
+    }
   }
 }

--- a/projects/ngx-openlayers/src/lib/interactions/snap.component.ts
+++ b/projects/ngx-openlayers/src/lib/interactions/snap.component.ts
@@ -14,7 +14,7 @@ import { Geometry } from 'ol/geom';
   standalone: true,
 })
 export class SnapInteractionComponent implements OnInit, OnDestroy {
-  private map = inject(MapComponent);
+  private map = inject(MapComponent, { host: true });
 
   @Input()
   features?: Collection<Feature>;
@@ -40,7 +40,7 @@ export class SnapInteractionComponent implements OnInit, OnDestroy {
   @Output()
   unsnap: EventEmitter<SnapEvent>;
 
-  instance: Snap;
+  instance?: Snap;
 
   constructor() {
     this.olChange = new EventEmitter<SnapEvent>();
@@ -57,10 +57,12 @@ export class SnapInteractionComponent implements OnInit, OnDestroy {
     this.instance.on('snap', (event: SnapEvent) => this.snap.emit(event));
     this.instance.on('unsnap', (event: SnapEvent) => this.unsnap.emit(event));
 
-    this.map.instance.addInteraction(this.instance);
+    this.map.instance?.addInteraction(this.instance);
   }
 
   ngOnDestroy(): void {
-    this.map.instance.removeInteraction(this.instance);
+    if (this.instance) {
+      this.map.instance?.removeInteraction(this.instance);
+    }
   }
 }

--- a/projects/ngx-openlayers/src/lib/interactions/translate.component.ts
+++ b/projects/ngx-openlayers/src/lib/interactions/translate.component.ts
@@ -12,7 +12,7 @@ import { MapComponent } from '../map.component';
   standalone: true,
 })
 export class TranslateInteractionComponent implements OnInit, OnDestroy {
-  private map = inject(MapComponent);
+  private map = inject(MapComponent, { host: true });
 
   @Input()
   features?: Collection<Feature>;
@@ -32,7 +32,7 @@ export class TranslateInteractionComponent implements OnInit, OnDestroy {
   @Output()
   translating: EventEmitter<TranslateEvent>;
 
-  instance: Translate;
+  instance?: Translate;
 
   constructor() {
     this.olChange = new EventEmitter<TranslateEvent>();
@@ -51,10 +51,12 @@ export class TranslateInteractionComponent implements OnInit, OnDestroy {
     this.instance.on('translatestart', (event: TranslateEvent) => this.translateStart.emit(event));
     this.instance.on('translating', (event: TranslateEvent) => this.translating.emit(event));
 
-    this.map.instance.addInteraction(this.instance);
+    this.map.instance?.addInteraction(this.instance);
   }
 
   ngOnDestroy(): void {
-    this.map.instance.removeInteraction(this.instance);
+    if (this.instance) {
+      this.map.instance?.removeInteraction(this.instance);
+    }
   }
 }

--- a/projects/ngx-openlayers/src/lib/layers/layer.component.ts
+++ b/projects/ngx-openlayers/src/lib/layers/layer.component.ts
@@ -39,7 +39,7 @@ export abstract class LayerComponent implements OnInit, OnChanges, OnDestroy {
   postrender: (evt: RenderEvent) => void;
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  instance: any;
+  instance?: any;
   componentType = 'layer';
 
   private readonly mapComponent = inject(MapComponent);
@@ -54,11 +54,11 @@ export abstract class LayerComponent implements OnInit, OnChanges, OnDestroy {
     if (this.postrender !== null && this.postrender !== undefined) {
       this.instance.on('postrender', this.postrender);
     }
-    this.host.instance.getLayers().push(this.instance);
+    this.host.instance?.getLayers().push(this.instance);
   }
 
   ngOnDestroy(): void {
-    this.host.instance.getLayers().remove(this.instance);
+    this.host.instance?.getLayers().remove(this.instance);
   }
 
   ngOnChanges(changes: SimpleChanges): void {

--- a/projects/ngx-openlayers/src/lib/layers/layergroup.component.ts
+++ b/projects/ngx-openlayers/src/lib/layers/layergroup.component.ts
@@ -35,7 +35,7 @@ export class LayerGroupComponent implements OnInit, OnDestroy, OnChanges {
     [x: string]: unknown;
   };
 
-  public instance: Group;
+  public instance?: Group;
   componentType = 'layer';
   private readonly map = inject(MapComponent);
   private readonly group = inject(LayerGroupComponent, { skipSelf: true, optional: true });
@@ -48,7 +48,7 @@ export class LayerGroupComponent implements OnInit, OnDestroy, OnChanges {
   }
 
   ngOnDestroy(): void {
-    this.host.instance.getLayers().remove(this.instance);
+    this.host.instance?.getLayers().remove(this.instance);
   }
 
   ngOnChanges(changes: SimpleChanges): void {

--- a/projects/ngx-openlayers/src/lib/map.component.ts
+++ b/projects/ngx-openlayers/src/lib/map.component.ts
@@ -70,7 +70,7 @@ export class MapComponent implements OnInit, AfterViewInit, OnChanges {
   @Output()
   singleClick: EventEmitter<MapBrowserEvent>;
 
-  instance: Map;
+  instance?: Map;
   componentType = 'map';
   // we pass empty arrays to not get default controls/interactions because we have our own directives
   controls: Control[] = [];
@@ -120,6 +120,8 @@ export class MapComponent implements OnInit, AfterViewInit, OnChanges {
   }
 
   ngAfterViewInit(): void {
-    this.instance.updateSize();
+    if (this.instance) {
+      this.instance.updateSize();
+    }
   }
 }

--- a/projects/ngx-openlayers/src/lib/overlay.component.ts
+++ b/projects/ngx-openlayers/src/lib/overlay.component.ts
@@ -33,20 +33,20 @@ export class OverlayComponent implements OnInit, OnDestroy {
   autoPanMargin: number;
 
   componentType = 'overlay';
-  instance: Overlay;
+  instance?: Overlay;
   element: HTMLElement;
 
   ngOnInit(): void {
     if (this.content) {
       this.element = this.content.elementRef.nativeElement;
       this.instance = new Overlay(this);
-      this.map.instance.addOverlay(this.instance);
+      this.map.instance?.addOverlay(this.instance);
     }
   }
 
   ngOnDestroy(): void {
     if (this.instance) {
-      this.map.instance.removeOverlay(this.instance);
+      this.map.instance?.removeOverlay(this.instance);
     }
   }
 }

--- a/projects/ngx-openlayers/src/lib/sources/bingmaps.component.ts
+++ b/projects/ngx-openlayers/src/lib/sources/bingmaps.component.ts
@@ -32,7 +32,7 @@ export class SourceBingmapsComponent extends SourceComponent implements OnInit {
   @Input()
   placeholderTiles = false;
 
-  instance: BingMaps;
+  instance?: BingMaps;
   host = inject(LayerTileComponent, { host: true });
 
   ngOnInit(): void {

--- a/projects/ngx-openlayers/src/lib/sources/cluster.component.ts
+++ b/projects/ngx-openlayers/src/lib/sources/cluster.component.ts
@@ -32,8 +32,8 @@ export class SourceClusterComponent extends SourceComponent implements AfterCont
 
   @ContentChild(SourceVectorComponent)
   sourceVectorComponent: SourceVectorComponent;
-  source: Vector;
-  instance: Cluster<Feature<Geometry>>;
+  source?: Vector;
+  instance?: Cluster<Feature<Geometry>>;
   host = inject(LayerVectorComponent, { host: true });
 
   ngAfterContentInit(): void {

--- a/projects/ngx-openlayers/src/lib/sources/geojson.component.ts
+++ b/projects/ngx-openlayers/src/lib/sources/geojson.component.ts
@@ -22,7 +22,7 @@ export class SourceGeoJSONComponent extends SourceComponent implements OnInit {
   @Input()
   url: string;
 
-  instance: Vector;
+  instance?: Vector;
   format: FeatureFormat;
   host = inject(LayerVectorComponent, { host: true });
 

--- a/projects/ngx-openlayers/src/lib/sources/imagearcgisrest.component.ts
+++ b/projects/ngx-openlayers/src/lib/sources/imagearcgisrest.component.ts
@@ -41,7 +41,7 @@ export class SourceImageArcGISRestComponent extends SourceComponent implements O
   @Output()
   imageLoadError = new EventEmitter<ImageSourceEvent>();
 
-  instance: ImageArcGISRest;
+  instance?: ImageArcGISRest;
   host = inject(LayerImageComponent, { host: true });
 
   ngOnInit(): void {

--- a/projects/ngx-openlayers/src/lib/sources/imagestatic.component.ts
+++ b/projects/ngx-openlayers/src/lib/sources/imagestatic.component.ts
@@ -46,7 +46,7 @@ export class SourceImageStaticComponent extends SourceComponent implements OnIni
   @Output()
   imageLoadError = new EventEmitter<ImageSourceEvent>();
 
-  instance: ImageStatic;
+  instance?: ImageStatic;
   host = inject(LayerImageComponent, { host: true });
 
   setLayerSource(): void {

--- a/projects/ngx-openlayers/src/lib/sources/imagewms.component.ts
+++ b/projects/ngx-openlayers/src/lib/sources/imagewms.component.ts
@@ -40,7 +40,7 @@ export class SourceImageWMSComponent extends SourceComponent implements OnChange
   @Output() imageLoadEnd = new EventEmitter<ImageSourceEvent>();
   @Output() imageLoadError = new EventEmitter<ImageSourceEvent>();
 
-  instance: ImageWMS;
+  instance?: ImageWMS;
   host = inject(LayerImageComponent, { host: true });
 
   ngOnInit(): void {

--- a/projects/ngx-openlayers/src/lib/sources/osm.component.ts
+++ b/projects/ngx-openlayers/src/lib/sources/osm.component.ts
@@ -39,7 +39,7 @@ export class SourceOsmComponent extends SourceXYZComponent implements AfterConte
   @Output()
   tileLoadError: EventEmitter<TileSourceEvent> = new EventEmitter<TileSourceEvent>();
 
-  instance: OSM;
+  instance?: OSM;
 
   ngAfterContentInit(): void {
     if (this.tileGridXYZ) {

--- a/projects/ngx-openlayers/src/lib/sources/raster.component.ts
+++ b/projects/ngx-openlayers/src/lib/sources/raster.component.ts
@@ -40,16 +40,18 @@ export class SourceRasterComponent extends SourceComponent implements AfterConte
   @Output()
   afterOperations: EventEmitter<RasterSourceEvent> = new EventEmitter<RasterSourceEvent>();
 
-  instance: Raster;
+  instance?: Raster;
   sources: Source[] = [];
   host = inject(LayerImageComponent, { host: true });
 
   @ContentChild(SourceComponent)
   set source(sourceComponent: SourceComponent) {
-    this.sources = [sourceComponent.instance];
-    if (this.instance) {
-      // Openlayer doesn't handle sources update. Just recreate Raster instance.
-      this.init();
+    if (sourceComponent.instance) {
+      this.sources = [sourceComponent.instance];
+      if (this.instance) {
+        // Openlayer doesn't handle sources update. Just recreate Raster instance.
+        this.init();
+      }
     }
   }
 

--- a/projects/ngx-openlayers/src/lib/sources/source.component.ts
+++ b/projects/ngx-openlayers/src/lib/sources/source.component.ts
@@ -9,10 +9,10 @@ export abstract class SourceComponent implements OnDestroy {
   @Input()
   attributions: AttributionLike;
 
-  public instance: Source;
+  public instance?: Source;
   public componentType = 'source';
 
-  protected host: LayerComponent;
+  protected host: LayerComponent | null = null;
 
   ngOnDestroy(): void {
     if (this.host && this.host.instance) {

--- a/projects/ngx-openlayers/src/lib/sources/tilejson.component.ts
+++ b/projects/ngx-openlayers/src/lib/sources/tilejson.component.ts
@@ -13,7 +13,7 @@ export class SourceTileJSONComponent extends SourceComponent implements OnInit {
   @Input()
   url: string;
 
-  instance: TileJSON;
+  instance?: TileJSON;
   host = inject(LayerTileComponent, { host: true });
 
   ngOnInit(): void {

--- a/projects/ngx-openlayers/src/lib/sources/tilewms.component.ts
+++ b/projects/ngx-openlayers/src/lib/sources/tilewms.component.ts
@@ -28,7 +28,7 @@ export class SourceTileWMSComponent extends SourceComponent implements OnChanges
   @Input() urls: string[];
   @Input() wrapX: boolean;
 
-  instance: TileWMS;
+  instance?: TileWMS;
   host = inject(LayerTileComponent, { host: true });
 
   ngOnInit(): void {

--- a/projects/ngx-openlayers/src/lib/sources/tilewmts.component.ts
+++ b/projects/ngx-openlayers/src/lib/sources/tilewmts.component.ts
@@ -30,7 +30,7 @@ export class SourceTileWMTSComponent extends SourceComponent implements AfterCon
   @Input()
   crossOrigin?: Options['crossOrigin'];
   @Input()
-  tileGrid: Options['tileGrid'];
+  tileGrid!: Options['tileGrid'];
   @Input()
   projection: Options['projection'];
   @Input()
@@ -72,7 +72,7 @@ export class SourceTileWMTSComponent extends SourceComponent implements AfterCon
   @ContentChild(TileGridWMTSComponent)
   tileGridWMTS: TileGridWMTSComponent;
 
-  instance: WMTS;
+  instance?: WMTS;
   host = inject(LayerTileComponent, { host: true });
 
   ngOnChanges(changes: SimpleChanges): void {
@@ -95,11 +95,13 @@ export class SourceTileWMTSComponent extends SourceComponent implements AfterCon
   }
 
   setLayerSource(): void {
-    this.instance = new WMTS(this);
-    this.instance.on('tileloadstart', (event: TileSourceEvent) => this.tileLoadStart.emit(event));
-    this.instance.on('tileloadend', (event: TileSourceEvent) => this.tileLoadEnd.emit(event));
-    this.instance.on('tileloaderror', (event: TileSourceEvent) => this.tileLoadError.emit(event));
-    this.host.instance.setSource(this.instance);
+    if (this.tileGrid) {
+      this.instance = new WMTS(this);
+      this.instance.on('tileloadstart', (event: TileSourceEvent) => this.tileLoadStart.emit(event));
+      this.instance.on('tileloadend', (event: TileSourceEvent) => this.tileLoadEnd.emit(event));
+      this.instance.on('tileloaderror', (event: TileSourceEvent) => this.tileLoadError.emit(event));
+      this.host.instance.setSource(this.instance);
+    }
   }
 
   ngAfterContentInit(): void {

--- a/projects/ngx-openlayers/src/lib/sources/utfgrid.component.ts
+++ b/projects/ngx-openlayers/src/lib/sources/utfgrid.component.ts
@@ -14,7 +14,7 @@ export class SourceUTFGridComponent extends SourceComponent implements OnInit {
   @Input() tileJSON: Config;
   @Input() url: string;
 
-  instance: UTFGrid;
+  instance?: UTFGrid;
   host = inject(LayerTileComponent, { host: true });
 
   ngOnInit(): void {

--- a/projects/ngx-openlayers/src/lib/sources/vector.component.ts
+++ b/projects/ngx-openlayers/src/lib/sources/vector.component.ts
@@ -48,7 +48,7 @@ export class SourceVectorComponent extends SourceComponent implements OnInit {
     vectorSource: Vector
   ) => void;
 
-  instance: Vector;
+  instance?: Vector;
   host = inject(LayerVectorComponent, { host: true });
 
   ngOnInit(): void {

--- a/projects/ngx-openlayers/src/lib/sources/vectortile.component.ts
+++ b/projects/ngx-openlayers/src/lib/sources/vectortile.component.ts
@@ -40,10 +40,10 @@ export class SourceVectorTileComponent extends SourceComponent implements AfterC
   @ContentChild(TileGridComponent)
   tileGridComponent: TileGridComponent;
 
-  format: FeatureFormat<RenderFeature>;
-  tileGrid: TileGrid;
+  format?: FeatureFormat<RenderFeature>;
+  tileGrid?: TileGrid;
 
-  instance: VectorTile<FeatureLike>;
+  instance?: VectorTile<FeatureLike>;
   host = inject(LayerVectorTileComponent, { host: true });
 
   /* need the children to construct the OL3 object */

--- a/projects/ngx-openlayers/src/lib/sources/xyz.component.ts
+++ b/projects/ngx-openlayers/src/lib/sources/xyz.component.ts
@@ -45,7 +45,7 @@ export class SourceXYZComponent extends SourceComponent implements AfterContentI
   @Input()
   maxZoom: number;
   @Input()
-  tileGrid: TileGrid;
+  tileGrid?: TileGrid;
   @Input()
   tileLoadFunction?: LoadFunction;
   @Input()
@@ -71,7 +71,7 @@ export class SourceXYZComponent extends SourceComponent implements AfterContentI
   @Output()
   tileLoadError: EventEmitter<TileSourceEvent> = new EventEmitter<TileSourceEvent>();
 
-  instance: XYZ;
+  instance?: XYZ;
   host = inject(LayerTileComponent, { optional: true, host: true });
 
   ngAfterContentInit(): void {

--- a/projects/ngx-openlayers/src/lib/styles/circle.component.ts
+++ b/projects/ngx-openlayers/src/lib/styles/circle.component.ts
@@ -18,7 +18,7 @@ export class StyleCircleComponent implements AfterContentInit, OnChanges, OnDest
   stroke: Stroke;
 
   componentType = 'style-circle';
-  instance: Circle;
+  instance?: Circle;
 
   /**
    * WORK-AROUND: since the re-rendering is not triggered on style change
@@ -36,7 +36,7 @@ export class StyleCircleComponent implements AfterContentInit, OnChanges, OnDest
   ngAfterContentInit(): void {
     // console.log('creating ol.style.Circle instance with: ', this);
     this.instance = new Circle(this);
-    this.host.instance.setImage(this.instance);
+    this.host.instance?.setImage(this.instance);
     this.host.update();
   }
 
@@ -52,6 +52,6 @@ export class StyleCircleComponent implements AfterContentInit, OnChanges, OnDest
 
   ngOnDestroy(): void {
     // console.log('removing aol-style-circle');
-    this.host.instance.setImage(null);
+    this.host.instance?.setImage(null);
   }
 }

--- a/projects/ngx-openlayers/src/lib/styles/fill.component.ts
+++ b/projects/ngx-openlayers/src/lib/styles/fill.component.ts
@@ -15,7 +15,7 @@ export class StyleFillComponent implements OnInit, OnChanges {
   @Input()
   color: Color | ColorLike;
 
-  instance: Fill;
+  instance?: Fill;
   private readonly host: StyleComponent | StyleCircleComponent | StyleTextComponent;
 
   constructor() {
@@ -40,7 +40,7 @@ export class StyleFillComponent implements OnInit, OnChanges {
     // console.log('creating ol.style.Fill instance with: ', this);
     this.instance = new Fill(this);
     if (this.host instanceof StyleComponent || this.host instanceof StyleTextComponent) {
-      this.host.instance.setFill(this.instance);
+      this.host.instance?.setFill(this.instance);
     } else {
       this.host.fill = this.instance;
     }

--- a/projects/ngx-openlayers/src/lib/styles/icon.component.ts
+++ b/projects/ngx-openlayers/src/lib/styles/icon.component.ts
@@ -48,12 +48,12 @@ export class StyleIconComponent implements OnInit, OnChanges {
   @Input()
   src: string;
 
-  instance: Icon;
+  instance?: Icon;
 
   ngOnInit(): void {
     // console.log('creating ol.style.Icon instance with: ', this);
     this.instance = new Icon(this);
-    this.host.instance.setImage(this.instance);
+    this.host.instance?.setImage(this.instance);
   }
 
   ngOnChanges(changes: SimpleChanges): void {
@@ -71,7 +71,7 @@ export class StyleIconComponent implements OnInit, OnChanges {
     }
     if (changes.src) {
       this.instance = new Icon(this);
-      this.host.instance.setImage(this.instance);
+      this.host.instance?.setImage(this.instance);
     }
     this.host.update();
     // console.log('changes detected in aol-style-icon: ', changes);

--- a/projects/ngx-openlayers/src/lib/styles/stroke.component.ts
+++ b/projects/ngx-openlayers/src/lib/styles/stroke.component.ts
@@ -25,7 +25,7 @@ export class StyleStrokeComponent implements OnInit, OnChanges {
   @Input()
   width: number;
 
-  instance: Stroke;
+  instance?: Stroke;
   private readonly host: StyleComponent | StyleCircleComponent | StyleTextComponent;
 
   constructor() {
@@ -51,7 +51,7 @@ export class StyleStrokeComponent implements OnInit, OnChanges {
     this.instance = new Stroke(this);
 
     if (this.host instanceof StyleComponent || this.host instanceof StyleTextComponent) {
-      this.host.instance.setStroke(this.instance);
+      this.host.instance?.setStroke(this.instance);
     } else {
       this.host.stroke = this.instance;
     }

--- a/projects/ngx-openlayers/src/lib/styles/style.component.ts
+++ b/projects/ngx-openlayers/src/lib/styles/style.component.ts
@@ -24,13 +24,13 @@ export class StyleComponent implements OnInit {
   @Input()
   zIndex: number;
 
-  instance: Style;
+  instance?: Style;
   componentType = 'style';
-  private host: FeatureComponent | LayerVectorComponent;
+  private host: FeatureComponent | LayerVectorComponent | null;
 
   constructor() {
-    const featureHost = inject(FeatureComponent, { optional: true });
-    const layerHost = inject(LayerVectorComponent, { optional: true });
+    const featureHost = inject(FeatureComponent, { optional: true, host: true });
+    const layerHost = inject(LayerVectorComponent, { optional: true, host: true });
 
     // console.log('creating aol-style');
     this.host = !!featureHost ? featureHost : layerHost;
@@ -41,12 +41,16 @@ export class StyleComponent implements OnInit {
 
   update(): void {
     // console.log('updating style\'s host: ', this.host);
-    this.host.instance.changed();
+    if (this.host?.instance) {
+      this.host.instance.changed();
+    }
   }
 
   ngOnInit(): void {
     // console.log('creating aol-style instance with: ', this);
     this.instance = new Style(this);
-    this.host.instance.setStyle(this.instance);
+    if (this.host?.instance) {
+      this.host.instance.setStyle(this.instance);
+    }
   }
 }

--- a/projects/ngx-openlayers/src/lib/styles/styles.component.ts
+++ b/projects/ngx-openlayers/src/lib/styles/styles.component.ts
@@ -11,11 +11,11 @@ import { StyleComponent } from './style.component';
 export class StylesComponent implements AfterViewInit {
   @ContentChildren(StyleComponent) styles: StyleComponent[];
 
-  private readonly host: FeatureComponent | LayerVectorComponent;
+  private readonly host: FeatureComponent | LayerVectorComponent | null;
 
   constructor() {
-    const featureHost = inject(FeatureComponent, { optional: true });
-    const layerHost = inject(LayerVectorComponent, { optional: true });
+    const featureHost = inject(FeatureComponent, { optional: true, host: true });
+    const layerHost = inject(LayerVectorComponent, { optional: true, host: true });
 
     this.host = !!featureHost ? featureHost : layerHost;
     if (!this.host) {
@@ -24,10 +24,10 @@ export class StylesComponent implements AfterViewInit {
   }
 
   update(): void {
-    this.host.instance.changed();
+    this.host?.instance.changed();
   }
 
   ngAfterViewInit(): void {
-    this.host.instance.setStyle(this.styles.map(s => s.instance));
+    this.host?.instance.setStyle(this.styles.map((s) => s.instance));
   }
 }

--- a/projects/ngx-openlayers/src/lib/styles/text.component.ts
+++ b/projects/ngx-openlayers/src/lib/styles/text.component.ts
@@ -29,7 +29,7 @@ export class StyleTextComponent implements OnInit, OnChanges {
   @Input()
   textBaseLine: string | undefined;
 
-  instance: Text;
+  instance?: Text;
   componentType = 'style-text';
 
   constructor() {
@@ -44,7 +44,7 @@ export class StyleTextComponent implements OnInit, OnChanges {
   ngOnInit(): void {
     // console.log('creating ol.style.Text instance with: ', this);
     this.instance = new Text(this);
-    this.host.instance.setText(this.instance);
+    this.host?.instance?.setText(this.instance);
   }
 
   ngOnChanges(changes: SimpleChanges): void {
@@ -75,7 +75,7 @@ export class StyleTextComponent implements OnInit, OnChanges {
     if (changes.textBaseLine) {
       this.instance.setTextBaseline(changes.textBaseLine.currentValue);
     }
-    this.host.update();
+    this.host?.update();
     // console.log('changes detected in aol-style-text, setting new properties: ', changes);
   }
 }

--- a/projects/ngx-openlayers/src/lib/tilegrid.component.ts
+++ b/projects/ngx-openlayers/src/lib/tilegrid.component.ts
@@ -24,7 +24,7 @@ export class TileGridComponent implements OnInit, OnChanges {
   @Input()
   resolutions: number[];
 
-  instance: TileGrid;
+  instance?: TileGrid;
 
   ngOnInit(): void {
     if (!this.resolutions) {

--- a/projects/ngx-openlayers/src/lib/tilegridwmts.component.ts
+++ b/projects/ngx-openlayers/src/lib/tilegridwmts.component.ts
@@ -25,7 +25,7 @@ export class TileGridWMTSComponent extends TileGridComponent implements OnInit {
   @Input()
   widths?: number[];
 
-  instance: WMTS;
+  instance?: WMTS;
 
   ngOnInit(): void {
     this.instance = new WMTS(this);

--- a/projects/ngx-openlayers/src/lib/view.component.ts
+++ b/projects/ngx-openlayers/src/lib/view.component.ts
@@ -12,7 +12,7 @@ import { ProjectionLike } from 'ol/proj';
   standalone: true,
 })
 export class ViewComponent implements OnInit, OnChanges {
-  private host = inject(MapComponent);
+  private host = inject(MapComponent, { host: true });
 
   @Input()
   constrainRotation: boolean | number;
@@ -63,13 +63,13 @@ export class ViewComponent implements OnInit, OnChanges {
   @Output()
   changeCenter: EventEmitter<ObjectEvent> = new EventEmitter<ObjectEvent>();
 
-  instance: View;
+  instance?: View;
   componentType = 'view';
 
   ngOnInit(): void {
     // console.log('creating ol.View instance with: ', this);
     this.instance = new View(this);
-    this.host.instance.setView(this.instance);
+    this.host.instance?.setView(this.instance);
 
     this.instance.on('change:resolution', (event: ObjectEvent) => this.changeResolution.emit(event));
     this.instance.on('change:center', (event: ObjectEvent) => this.changeCenter.emit(event));
@@ -92,7 +92,7 @@ export class ViewComponent implements OnInit, OnChanges {
           break;
         case 'projection':
           this.instance = new View(this);
-          this.host.instance.setView(this.instance);
+          this.host.instance?.setView(this.instance);
           break;
         case 'center':
           /** Work-around: setting the center via setProperties does not work. */

--- a/projects/ngx-openlayers/src/public-api.ts
+++ b/projects/ngx-openlayers/src/public-api.ts
@@ -116,7 +116,6 @@ export {
   GeometryCircleComponent,
   CoordinateComponent,
   CollectionCoordinatesComponent,
-
   StylesComponent,
   StyleComponent,
   StyleCircleComponent,

--- a/src/app/styles/styles-composition.component.ts
+++ b/src/app/styles/styles-composition.component.ts
@@ -13,7 +13,7 @@ import {
   StylesComponent,
   StyleComponent,
   StyleIconComponent,
-  ViewComponent
+  ViewComponent,
 } from 'ngx-openlayers';
 
 @Component({
@@ -32,7 +32,7 @@ import {
     StylesComponent,
     StyleComponent,
     StyleIconComponent,
-    ViewComponent
+    ViewComponent,
   ],
   template: `
     <aol-map width="100%" height="100%">
@@ -46,7 +46,7 @@ import {
       <aol-layer-tile [opacity]="1"> <aol-source-osm></aol-source-osm> </aol-layer-tile>
 
       <aol-layer-vector>
-        <aol-source-vector >
+        <aol-source-vector>
           <aol-feature>
             <aol-geometry-point>
               <aol-coordinate [x]="marker.lon" [y]="marker.lat" srid="EPSG:4326"></aol-coordinate>

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,5 +13,5 @@ if (environment.production) {
 }
 
 bootstrapApplication(AppComponent, {
-  providers: [provideZoneChangeDetection(),provideRouter(routes), importProvidersFrom(HammerModule)],
+  providers: [provideZoneChangeDetection(), provideRouter(routes), importProvidersFrom(HammerModule)],
 }).catch((err) => console.log(err));

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,6 +29,6 @@
     "enableI18nLegacyMessageIdFormat": false,
     "strictInjectionParameters": true,
     "strictInputAccessModifiers": true,
-    "strictTemplates": true
+    "strictTemplates": true,
   }
 }


### PR DESCRIPTION
First proposition to manage component destruction if map is not already instantiated. 

Divided in 2 commits : 
- first commit: only add safeguard condition to component when destroy
- second commit: make map and some host component optionnal and safeguard every time, it is used in other component

Second commit is creating a big breaking change