### PR TITLE
fix: correctly instantiate map

### DIFF
--- a/projects/ngx-openlayers/src/lib/controls/attribution.component.ts
+++ b/projects/ngx-openlayers/src/lib/controls/attribution.component.ts
@@ -8,7 +8,7 @@ import { MapComponent } from '../map.component';
   standalone: true,
 })
 export class ControlAttributionComponent implements OnInit, OnDestroy {
-  private map = inject(MapComponent);
+  private map = inject(MapComponent, {host: true});
   private element = inject(ElementRef);
 
   @Input()

--- a/projects/ngx-openlayers/src/lib/controls/control.component.ts
+++ b/projects/ngx-openlayers/src/lib/controls/control.component.ts
@@ -9,7 +9,7 @@ import { MapComponent } from '../map.component';
   standalone: true,
 })
 export class ControlComponent implements OnInit, OnDestroy {
-  private map = inject(MapComponent);
+  private map = inject(MapComponent, {host: true});
 
   @ContentChild(ContentComponent, { static: true })
   content: ContentComponent;

--- a/projects/ngx-openlayers/src/lib/controls/default.component.ts
+++ b/projects/ngx-openlayers/src/lib/controls/default.component.ts
@@ -13,7 +13,7 @@ import { MapComponent } from '../map.component';
   standalone: true,
 })
 export class DefaultControlComponent implements OnInit, OnDestroy {
-  private map = inject(MapComponent);
+  private map = inject(MapComponent, {host: true});
 
   @Input()
   attribution: boolean;

--- a/projects/ngx-openlayers/src/lib/controls/fullscreen.component.ts
+++ b/projects/ngx-openlayers/src/lib/controls/fullscreen.component.ts
@@ -8,7 +8,7 @@ import { MapComponent } from '../map.component';
   standalone: true,
 })
 export class ControlFullScreenComponent implements OnInit, OnDestroy {
-  private map = inject(MapComponent);
+  private map = inject(MapComponent, {host: true});
 
   @Input()
   className: string;

--- a/projects/ngx-openlayers/src/lib/controls/mouseposition.component.ts
+++ b/projects/ngx-openlayers/src/lib/controls/mouseposition.component.ts
@@ -10,7 +10,7 @@ import { MapComponent } from '../map.component';
   standalone: true,
 })
 export class ControlMousePositionComponent implements OnInit, OnDestroy {
-  private map = inject(MapComponent);
+  private map = inject(MapComponent, {host: true});
   private element = inject(ElementRef);
 
   @Input()

--- a/projects/ngx-openlayers/src/lib/controls/overviewmap.component.ts
+++ b/projects/ngx-openlayers/src/lib/controls/overviewmap.component.ts
@@ -10,7 +10,7 @@ import { MapComponent } from '../map.component';
   standalone: true,
 })
 export class ControlOverviewMapComponent implements OnInit, OnChanges, OnDestroy {
-  private map = inject(MapComponent);
+  private map = inject(MapComponent, {host: true});
 
   @Input()
   collapsed: boolean;

--- a/projects/ngx-openlayers/src/lib/controls/rotate.component.ts
+++ b/projects/ngx-openlayers/src/lib/controls/rotate.component.ts
@@ -8,7 +8,7 @@ import { MapComponent } from '../map.component';
   standalone: true,
 })
 export class ControlRotateComponent implements OnInit, OnDestroy {
-  private map = inject(MapComponent);
+  private map = inject(MapComponent, {host: true});
 
   @Input()
   className: string;

--- a/projects/ngx-openlayers/src/lib/controls/scaleline.component.ts
+++ b/projects/ngx-openlayers/src/lib/controls/scaleline.component.ts
@@ -9,7 +9,7 @@ import { Units } from 'ol/control/ScaleLine';
   standalone: true,
 })
 export class ControlScaleLineComponent implements OnInit, OnDestroy {
-  private map = inject(MapComponent);
+  private map = inject(MapComponent, {host: true});
 
   @Input()
   units: Units;

--- a/projects/ngx-openlayers/src/lib/controls/zoom.component.ts
+++ b/projects/ngx-openlayers/src/lib/controls/zoom.component.ts
@@ -8,7 +8,7 @@ import { MapComponent } from '../map.component';
   standalone: true,
 })
 export class ControlZoomComponent implements OnInit, OnDestroy {
-  private map = inject(MapComponent);
+  private map = inject(MapComponent, {host: true});
 
   @Input()
   duration: number;

--- a/projects/ngx-openlayers/src/lib/controls/zoomslider.component.ts
+++ b/projects/ngx-openlayers/src/lib/controls/zoomslider.component.ts
@@ -8,7 +8,7 @@ import { MapComponent } from '../map.component';
   standalone: true,
 })
 export class ControlZoomSliderComponent implements OnInit, OnDestroy {
-  private map = inject(MapComponent);
+  private map = inject(MapComponent, {host: true});
 
   @Input()
   className: string;

--- a/projects/ngx-openlayers/src/lib/controls/zoomtoextent.component.ts
+++ b/projects/ngx-openlayers/src/lib/controls/zoomtoextent.component.ts
@@ -9,7 +9,7 @@ import { MapComponent } from '../map.component';
   standalone: true,
 })
 export class ControlZoomToExtentComponent implements OnInit, OnDestroy {
-  private map = inject(MapComponent);
+  private map = inject(MapComponent, {host: true});
 
   @Input()
   className: string;

--- a/projects/ngx-openlayers/src/lib/feature.component.ts
+++ b/projects/ngx-openlayers/src/lib/feature.component.ts
@@ -25,7 +25,7 @@ export class FeatureComponent implements OnInit, OnDestroy, OnChanges {
   }
 
   ngOnDestroy(): void {
-    this.host.instance.removeFeature(this.instance);
+    this.host.instance?.removeFeature(this.instance);
   }
 
   ngOnChanges(): void {

--- a/projects/ngx-openlayers/src/lib/interactions/default.component.ts
+++ b/projects/ngx-openlayers/src/lib/interactions/default.component.ts
@@ -9,7 +9,7 @@ import { MapComponent } from '../map.component';
   standalone: true,
 })
 export class DefaultInteractionComponent implements OnInit, OnDestroy {
-  private map = inject(MapComponent);
+  private map = inject(MapComponent, {host: true});
 
   instance: Collection<Interaction>;
 

--- a/projects/ngx-openlayers/src/lib/interactions/doubleclickzoom.component.ts
+++ b/projects/ngx-openlayers/src/lib/interactions/doubleclickzoom.component.ts
@@ -8,7 +8,7 @@ import { MapComponent } from '../map.component';
   standalone: true,
 })
 export class DoubleClickZoomInteractionComponent implements OnInit, OnDestroy {
-  private map = inject(MapComponent);
+  private map = inject(MapComponent, {host: true});
 
   @Input()
   duration: number;

--- a/projects/ngx-openlayers/src/lib/interactions/draganddrop.component.ts
+++ b/projects/ngx-openlayers/src/lib/interactions/draganddrop.component.ts
@@ -10,7 +10,7 @@ import { MapComponent } from '../map.component';
   standalone: true,
 })
 export class DragAndDropInteractionComponent implements OnInit, OnDestroy {
-  private map = inject(MapComponent);
+  private map = inject(MapComponent, {host: true});
 
   @Input()
   formatConstructors: FeatureFormat[];

--- a/projects/ngx-openlayers/src/lib/interactions/dragbox.component.ts
+++ b/projects/ngx-openlayers/src/lib/interactions/dragbox.component.ts
@@ -10,7 +10,7 @@ import { MapComponent } from '../map.component';
   standalone: true,
 })
 export class DragBoxInteractionComponent implements OnInit, OnDestroy {
-  private map = inject(MapComponent);
+  private map = inject(MapComponent, {host: true});
 
   @Input()
   className: string;

--- a/projects/ngx-openlayers/src/lib/interactions/dragpan.component.ts
+++ b/projects/ngx-openlayers/src/lib/interactions/dragpan.component.ts
@@ -10,7 +10,7 @@ import { MapComponent } from '../map.component';
   standalone: true,
 })
 export class DragPanInteractionComponent implements OnInit, OnDestroy {
-  private map = inject(MapComponent);
+  private map = inject(MapComponent, {host: true});
 
   @Input()
   condition: Condition;

--- a/projects/ngx-openlayers/src/lib/interactions/dragrotate.component.ts
+++ b/projects/ngx-openlayers/src/lib/interactions/dragrotate.component.ts
@@ -9,7 +9,7 @@ import { MapComponent } from '../map.component';
   standalone: true,
 })
 export class DragRotateInteractionComponent implements OnInit, OnDestroy {
-  private map = inject(MapComponent);
+  private map = inject(MapComponent, {host: true});
 
   @Input()
   condition: Condition;

--- a/projects/ngx-openlayers/src/lib/interactions/dragrotateandzoom.component.ts
+++ b/projects/ngx-openlayers/src/lib/interactions/dragrotateandzoom.component.ts
@@ -9,7 +9,7 @@ import { MapComponent } from '../map.component';
   standalone: true,
 })
 export class DragRotateAndZoomInteractionComponent implements OnInit, OnDestroy {
-  private map = inject(MapComponent);
+  private map = inject(MapComponent, {host: true});
 
   @Input()
   condition: Condition;

--- a/projects/ngx-openlayers/src/lib/interactions/dragzoom.component.ts
+++ b/projects/ngx-openlayers/src/lib/interactions/dragzoom.component.ts
@@ -9,7 +9,7 @@ import { MapComponent } from '../map.component';
   standalone: true,
 })
 export class DragZoomInteractionComponent implements OnInit, OnDestroy {
-  private map = inject(MapComponent);
+  private map = inject(MapComponent, {host: true});
 
   @Input()
   className: string;

--- a/projects/ngx-openlayers/src/lib/interactions/draw.component.ts
+++ b/projects/ngx-openlayers/src/lib/interactions/draw.component.ts
@@ -16,7 +16,7 @@ import { Type } from 'ol/geom/Geometry';
   standalone: true,
 })
 export class DrawInteractionComponent implements OnInit, OnDestroy {
-  private map = inject(MapComponent);
+  private map = inject(MapComponent, {host: true});
 
   @Input()
   clickTolerance?: number;

--- a/projects/ngx-openlayers/src/lib/interactions/modify.component.ts
+++ b/projects/ngx-openlayers/src/lib/interactions/modify.component.ts
@@ -15,7 +15,7 @@ import { MapComponent } from '../map.component';
   standalone: true,
 })
 export class ModifyInteractionComponent implements OnInit, OnDestroy {
-  private map = inject(MapComponent);
+  private map = inject(MapComponent, {host: true});
 
   @Input()
   condition?: Condition;

--- a/projects/ngx-openlayers/src/lib/interactions/mousewheelzoom.component.ts
+++ b/projects/ngx-openlayers/src/lib/interactions/mousewheelzoom.component.ts
@@ -8,7 +8,7 @@ import { MapComponent } from '../map.component';
   standalone: true,
 })
 export class MouseWheelZoomInteractionComponent implements OnInit, OnDestroy {
-  private map = inject(MapComponent);
+  private map = inject(MapComponent, {host: true});
 
   @Input()
   duration: number;

--- a/projects/ngx-openlayers/src/lib/interactions/pinchzoom.component.ts
+++ b/projects/ngx-openlayers/src/lib/interactions/pinchzoom.component.ts
@@ -8,7 +8,7 @@ import { MapComponent } from '../map.component';
   standalone: true,
 })
 export class PinchZoomInteractionComponent implements OnInit, OnDestroy {
-  private map = inject(MapComponent);
+  private map = inject(MapComponent, {host: true});
 
   @Input()
   duration: number;

--- a/projects/ngx-openlayers/src/lib/interactions/select.component.ts
+++ b/projects/ngx-openlayers/src/lib/interactions/select.component.ts
@@ -15,7 +15,7 @@ import { MapComponent } from '../map.component';
   standalone: true,
 })
 export class SelectInteractionComponent implements OnInit, OnDestroy {
-  private map = inject(MapComponent);
+  private map = inject(MapComponent, {host: true});
 
   @Input()
   addCondition?: Condition;

--- a/projects/ngx-openlayers/src/lib/interactions/snap.component.ts
+++ b/projects/ngx-openlayers/src/lib/interactions/snap.component.ts
@@ -14,7 +14,7 @@ import { Geometry } from 'ol/geom';
   standalone: true,
 })
 export class SnapInteractionComponent implements OnInit, OnDestroy {
-  private map = inject(MapComponent);
+  private map = inject(MapComponent, {host: true});
 
   @Input()
   features?: Collection<Feature>;

--- a/projects/ngx-openlayers/src/lib/interactions/translate.component.ts
+++ b/projects/ngx-openlayers/src/lib/interactions/translate.component.ts
@@ -12,7 +12,7 @@ import { MapComponent } from '../map.component';
   standalone: true,
 })
 export class TranslateInteractionComponent implements OnInit, OnDestroy {
-  private map = inject(MapComponent);
+  private map = inject(MapComponent, {host: true});
 
   @Input()
   features?: Collection<Feature>;

--- a/projects/ngx-openlayers/src/lib/layers/layer.component.ts
+++ b/projects/ngx-openlayers/src/lib/layers/layer.component.ts
@@ -54,11 +54,11 @@ export abstract class LayerComponent implements OnInit, OnChanges, OnDestroy {
     if (this.postrender !== null && this.postrender !== undefined) {
       this.instance.on('postrender', this.postrender);
     }
-    this.host.instance.getLayers().push(this.instance);
+    this.host.instance?.getLayers().push(this.instance);
   }
 
   ngOnDestroy(): void {
-    this.host.instance.getLayers().remove(this.instance);
+    this.host.instance?.getLayers().remove(this.instance);
   }
 
   ngOnChanges(changes: SimpleChanges): void {

--- a/projects/ngx-openlayers/src/lib/layers/layergroup.component.ts
+++ b/projects/ngx-openlayers/src/lib/layers/layergroup.component.ts
@@ -48,7 +48,7 @@ export class LayerGroupComponent implements OnInit, OnDestroy, OnChanges {
   }
 
   ngOnDestroy(): void {
-    this.host.instance.getLayers().remove(this.instance);
+    this.host.instance?.getLayers().remove(this.instance);
   }
 
   ngOnChanges(changes: SimpleChanges): void {

--- a/projects/ngx-openlayers/src/lib/map.component.ts
+++ b/projects/ngx-openlayers/src/lib/map.component.ts
@@ -8,7 +8,7 @@ import {
   OnInit,
   Output,
   SimpleChanges,
-  inject,
+  inject, input,
 } from '@angular/core';
 import Map from 'ol/Map';
 import MapBrowserEvent from 'ol/MapBrowserEvent';
@@ -22,7 +22,7 @@ import BaseObject from 'ol/Object';
 @Component({
   selector: 'aol-map',
   template: `
-    <div [style.width]="width" [style.height]="height"></div>
+    <div [style.width]="width()" [style.height]="height()"></div>
     <ng-content></ng-content>
   `,
   standalone: true,
@@ -30,22 +30,10 @@ import BaseObject from 'ol/Object';
 export class MapComponent implements OnInit, AfterViewInit, OnChanges {
   private host = inject(ElementRef);
 
-  @Input()
-  width = '100%';
-  @Input()
-  height = '100%';
-  @Input()
-  pixelRatio: number;
-  @Input()
-  keyboardEventTarget: HTMLElement | string;
-  @Input()
-  loadTilesWhileAnimating: boolean;
-  @Input()
-  loadTilesWhileInteracting: boolean;
-  @Input()
-  logo: string | boolean;
-  @Input()
-  renderer: 'canvas' | 'webgl';
+  width = input('100%');
+  height = input('100%');
+  pixelRatio = input<number>();
+  keyboardEventTarget = input<HTMLElement | string>();
 
   @Output()
   olClick: EventEmitter<MapBrowserEvent>;
@@ -70,11 +58,14 @@ export class MapComponent implements OnInit, AfterViewInit, OnChanges {
   @Output()
   singleClick: EventEmitter<MapBrowserEvent>;
 
-  instance: Map;
+  instance = new Map({
+    pixelRatio: this.pixelRatio(),
+    keyboardEventTarget: this.keyboardEventTarget(),
+    // we pass empty arrays to not get default controls/interactions because we have our own directives
+    controls: [],
+    interactions: [],
+  });
   componentType = 'map';
-  // we pass empty arrays to not get default controls/interactions because we have our own directives
-  controls: Control[] = [];
-  interactions: Interaction[] = [];
 
   constructor() {
     this.olClick = new EventEmitter<MapBrowserEvent>();
@@ -91,9 +82,6 @@ export class MapComponent implements OnInit, AfterViewInit, OnChanges {
   }
 
   ngOnInit(): void {
-    // console.log('creating ol.Map instance with:', this);
-    this.instance = new Map(this);
-    this.instance.setTarget(this.host.nativeElement.firstElementChild);
     this.instance.on('click', (event: MapBrowserEvent) => this.olClick.emit(event));
     this.instance.on('dblclick', (event: MapBrowserEvent) => this.dblClick.emit(event));
     this.instance.on('movestart', (event: MapEvent) => this.moveStart.emit(event));
@@ -108,9 +96,6 @@ export class MapComponent implements OnInit, AfterViewInit, OnChanges {
   }
 
   ngOnChanges(changes: SimpleChanges): void {
-    if (!this.instance) {
-      return;
-    }
     const properties: Parameters<BaseObject['setProperties']>[0] = {};
     for (const key in changes) {
       properties[key] = changes[key].currentValue;
@@ -120,6 +105,6 @@ export class MapComponent implements OnInit, AfterViewInit, OnChanges {
   }
 
   ngAfterViewInit(): void {
-    this.instance.updateSize();
+    this.instance.setTarget(this.host.nativeElement.firstElementChild);
   }
 }

--- a/projects/ngx-openlayers/src/lib/sources/source.component.ts
+++ b/projects/ngx-openlayers/src/lib/sources/source.component.ts
@@ -12,7 +12,7 @@ export abstract class SourceComponent implements OnDestroy {
   public instance: Source;
   public componentType = 'source';
 
-  protected host: LayerComponent;
+  protected host: LayerComponent | null = null;
 
   ngOnDestroy(): void {
     if (this.host && this.host.instance) {

--- a/projects/ngx-openlayers/src/lib/styles/circle.component.ts
+++ b/projects/ngx-openlayers/src/lib/styles/circle.component.ts
@@ -52,6 +52,6 @@ export class StyleCircleComponent implements AfterContentInit, OnChanges, OnDest
 
   ngOnDestroy(): void {
     // console.log('removing aol-style-circle');
-    this.host.instance.setImage(null);
+    this.host.instance?.setImage(null);
   }
 }

--- a/projects/ngx-openlayers/src/lib/styles/style.component.ts
+++ b/projects/ngx-openlayers/src/lib/styles/style.component.ts
@@ -26,11 +26,11 @@ export class StyleComponent implements OnInit {
 
   instance: Style;
   componentType = 'style';
-  private host: FeatureComponent | LayerVectorComponent;
+  private host: FeatureComponent | LayerVectorComponent | null;
 
   constructor() {
-    const featureHost = inject(FeatureComponent, { optional: true });
-    const layerHost = inject(LayerVectorComponent, { optional: true });
+    const featureHost = inject(FeatureComponent, { optional: true, host: true });
+    const layerHost = inject(LayerVectorComponent, { optional: true, host: true });
 
     // console.log('creating aol-style');
     this.host = !!featureHost ? featureHost : layerHost;
@@ -41,12 +41,16 @@ export class StyleComponent implements OnInit {
 
   update(): void {
     // console.log('updating style\'s host: ', this.host);
-    this.host.instance.changed();
+    if (this.host?.instance) {
+      this.host.instance.changed();
+    }
   }
 
   ngOnInit(): void {
     // console.log('creating aol-style instance with: ', this);
     this.instance = new Style(this);
-    this.host.instance.setStyle(this.instance);
+    if (this.host?.instance) {
+      this.host.instance.setStyle(this.instance);
+    }
   }
 }

--- a/projects/ngx-openlayers/src/lib/styles/styles.component.ts
+++ b/projects/ngx-openlayers/src/lib/styles/styles.component.ts
@@ -11,11 +11,11 @@ import { StyleComponent } from './style.component';
 export class StylesComponent implements AfterViewInit {
   @ContentChildren(StyleComponent) styles: StyleComponent[];
 
-  private readonly host: FeatureComponent | LayerVectorComponent;
+  private readonly host: FeatureComponent | LayerVectorComponent | null;
 
   constructor() {
-    const featureHost = inject(FeatureComponent, { optional: true });
-    const layerHost = inject(LayerVectorComponent, { optional: true });
+    const featureHost = inject(FeatureComponent, { optional: true, host: true });
+    const layerHost = inject(LayerVectorComponent, { optional: true, host: true });
 
     this.host = !!featureHost ? featureHost : layerHost;
     if (!this.host) {
@@ -24,10 +24,10 @@ export class StylesComponent implements AfterViewInit {
   }
 
   update(): void {
-    this.host.instance.changed();
+    this.host?.instance.changed();
   }
 
   ngAfterViewInit(): void {
-    this.host.instance.setStyle(this.styles.map(s => s.instance));
+    this.host?.instance.setStyle(this.styles.map(s => s.instance));
   }
 }

--- a/projects/ngx-openlayers/src/lib/styles/text.component.ts
+++ b/projects/ngx-openlayers/src/lib/styles/text.component.ts
@@ -44,7 +44,7 @@ export class StyleTextComponent implements OnInit, OnChanges {
   ngOnInit(): void {
     // console.log('creating ol.style.Text instance with: ', this);
     this.instance = new Text(this);
-    this.host.instance.setText(this.instance);
+    this.host?.instance.setText(this.instance);
   }
 
   ngOnChanges(changes: SimpleChanges): void {
@@ -75,7 +75,7 @@ export class StyleTextComponent implements OnInit, OnChanges {
     if (changes.textBaseLine) {
       this.instance.setTextBaseline(changes.textBaseLine.currentValue);
     }
-    this.host.update();
+    this.host?.update();
     // console.log('changes detected in aol-style-text, setting new properties: ', changes);
   }
 }

--- a/projects/ngx-openlayers/src/lib/view.component.ts
+++ b/projects/ngx-openlayers/src/lib/view.component.ts
@@ -12,7 +12,7 @@ import { ProjectionLike } from 'ol/proj';
   standalone: true,
 })
 export class ViewComponent implements OnInit, OnChanges {
-  private host = inject(MapComponent);
+  private host = inject(MapComponent, {host: true});
 
   @Input()
   constrainRotation: boolean | number;
@@ -69,7 +69,7 @@ export class ViewComponent implements OnInit, OnChanges {
   ngOnInit(): void {
     // console.log('creating ol.View instance with: ', this);
     this.instance = new View(this);
-    this.host.instance.setView(this.instance);
+    this.host.instance?.setView(this.instance);
 
     this.instance.on('change:resolution', (event: ObjectEvent) => this.changeResolution.emit(event));
     this.instance.on('change:center', (event: ObjectEvent) => this.changeCenter.emit(event));
@@ -92,7 +92,7 @@ export class ViewComponent implements OnInit, OnChanges {
           break;
         case 'projection':
           this.instance = new View(this);
-          this.host.instance.setView(this.instance);
+          this.host.instance?.setView(this.instance);
           break;
         case 'center':
           /** Work-around: setting the center via setProperties does not work. */

--- a/yarn.lock
+++ b/yarn.lock
@@ -7090,10 +7090,10 @@ undici-types@~7.18.0:
   resolved "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz#29357a89e7b7ca4aef3bf0fd3fd0cd73884229e9"
   integrity sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==
 
-undici@7.22.0:
-  version "7.22.0"
-  resolved "https://registry.npmjs.org/undici/-/undici-7.22.0.tgz#7a82590a5908e504a47d85c60b0f89ca14240e60"
-  integrity sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==
+undici@7.22.0, undici@7.24.0:
+  version "7.24.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-7.24.0.tgz#c7349cdede0db44226b5930783b11207831a5eaf"
+  integrity sha512-jxytwMHhsbdpBXxLAcuu0fzlQeXCNnWdDyRHpvWsUl8vd98UwYdl9YTyn8/HcpcJPC3pwUveefsa3zTxyD/ERg==
 
 unique-filename@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
Change to manage the destruction of subcomponent referencing to the map. 
In this PR : 
- instance of map is created on constructor with input signal (input signal are not mandatory, we can also instantiate an empty map and set the properties in ngOnInit
- some options were removed because they no longer exist in MapOptions
- setTarget is done in the afterViewInit to avoid error message in console
- injection of mapComponent is declaring that it is the host
- Component that check an optional host have now the right typing